### PR TITLE
Add more SGX tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,14 @@ This repository contains instructions to run SGX experiments on Faasm.
 For the moment, though, it contains instructions to provision an SGX-enabled
 VM and test that it can interact with the attestation service in Azure.
 
+The installation scripts follow [Azure's example](https://github.com/Azure-Samples/microsoft-azure-attestation/tree/master/intel.sdk.attest.sample),
+and deviate from it where the instructions need updating.
+In particular, the scripts are very sensitive to code, driver, or OS versions.
+
 ## Quick start from fresh VM
 
 Install the required dependencies:
+
 ```bash
 sudo apt update && sudo apt upgrade -y
 sudo apt install -y \
@@ -16,16 +21,19 @@ sudo apt install -y \
 ```
 
 Initialise the virtual environment:
+
 ```bash
 source ./bin/workon.sh
 ```
 
 Now configure the APT repos:
+
 ```bash
 sudo inv sgx.configure
 ```
 
 Install the remaining dependencies:
+
 ```bash
 sudo apt update && sudo apt install -y \
     az-dcap-client \
@@ -37,12 +45,15 @@ sudo apt update && sudo apt install -y \
     libsgx-dcap-ql-dev \
     libssl-dev
 ```
+
 Finally, install dependencies. This installes the DCAP driver, the SGX SDK and the .NET Core SDK (if necessary) and clones [this repo](https://github.com/Azure-Samples/microsoft-azure-attestation/).
+
 ```bash
 inv sgx.install
 ```
 
 And source your environment:
+
 ```bash
 source ~/.bashrc
 ```
@@ -50,6 +61,7 @@ source ~/.bashrc
 ## Running the Demo
 
 To run the demo:
+
 ```bash
 inv sgx.demo
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # SGX Experiments in Faasm
 
+This repository contains instructions to run SGX experiments on Faasm.
+For the moment, though, it contains instructions to provision an SGX-enabled
+VM and test that it can interact with the attestation service in Azure.
+
 ## Quick start from fresh VM
 
 Install the required dependencies:

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,7 +1,13 @@
 from invoke import Collection
 
+from . import attestation
+from . import policy
 from . import sgx
+from . import vm
 
 ns = Collection(
+    attestation,
+    policy,
     sgx,
+    vm,
 )

--- a/tasks/attestation.py
+++ b/tasks/attestation.py
@@ -1,0 +1,68 @@
+from invoke import task
+from subprocess import run
+from tasks.util.env import (
+    AZURE_ATTESTATION_PROVIDER_NAME,
+    AZURE_RESOURCE_GROUP,
+    AZURE_SGX_LOCATION,
+)
+
+
+def run_az_cmd(cmd):
+    _cmd = "az {}".format(cmd)
+    print(_cmd)
+    run(_cmd, shell=True, check=True)
+
+
+@task
+def set_up(ctx):
+    """
+    Set up Azure Attestation Service extension (only needs to be done once)
+    """
+    run_az_cmd("extension add --name attestation")
+    run_az_cmd("extension show --name attestation --query version")
+    run_az_cmd("provider register --name Microsoft.Attestation")
+
+
+def run_az_attestation_cmd(action, az_args=None):
+    cmd = [
+        "az",
+        "attestation {}".format(action),
+        "--resource-group {}".format(AZURE_RESOURCE_GROUP),
+        "--name {}".format(AZURE_ATTESTATION_PROVIDER_NAME),
+    ]
+
+    if az_args:
+        cmd.extend(az_args)
+
+    cmd = " ".join(cmd)
+    print(cmd)
+    run(cmd, shell=True, check=True)
+
+
+@task
+def provider_create(ctx):
+    """
+    Create attestation provider
+    """
+    run_az_attestation_cmd(
+        "create",
+        [
+            "--location {}".format(AZURE_SGX_LOCATION),
+        ],
+    )
+
+
+@task
+def provider_show(ctx):
+    """
+    Show attestation provider information
+    """
+    run_az_attestation_cmd("show")
+
+
+@task
+def provider_delete(ctx):
+    """
+    Delete attestation provider
+    """
+    run_az_attestation_cmd("delete")

--- a/tasks/policy.py
+++ b/tasks/policy.py
@@ -1,0 +1,46 @@
+from invoke import task
+from subprocess import run
+from tasks.util.env import (
+    AZURE_ATTESTATION_PROVIDER_NAME,
+    AZURE_ATTESTATION_TYPE,
+    AZURE_RESOURCE_GROUP,
+)
+
+
+def run_az_policy_cmd(action, az_args=None):
+    cmd = [
+        "az",
+        "attestation policy {}".format(action),
+        "--resource-group {}".format(AZURE_RESOURCE_GROUP),
+        "--name {}".format(AZURE_ATTESTATION_PROVIDER_NAME),
+        "--attestation-type {}".format(AZURE_ATTESTATION_TYPE),
+    ]
+
+    if az_args:
+        cmd.extend(az_args)
+
+    cmd = " ".join(cmd)
+    print(cmd)
+    run(cmd, shell=True, check=True)
+
+
+@task
+def show(ctx):
+    """
+    Show current attestation policy
+    """
+    run_az_policy_cmd("show")
+
+
+@task
+def set(ctx, file_path, jwt=False):
+    """
+    Set new attesation policy file
+    """
+    run_az_policy_cmd(
+        "set",
+        [
+            "--new--attestation--policy-file {}".format(file_path),
+            "--policy-format JWT" if jwt else "",
+        ],
+    )

--- a/tasks/util/env.py
+++ b/tasks/util/env.py
@@ -5,3 +5,20 @@ PROJ_ROOT = dirname(dirname(dirname(realpath(__file__))))
 BIN_DIR = join(PROJ_ROOT, "bin")
 
 SGX_INSTALL_DIR = "/opt/intel"
+
+# Note that this is copied from faasm/experiment-base/tasks/util/env.py
+AZURE_RESOURCE_GROUP = "faasm"
+
+# SGX VM config
+
+AZURE_SGX_VM_SIZE = "Standard_DC2ds_v3"
+AZURE_SGX_LOCATION = "eastus2"
+AZURE_SGX_VM_NAME = "faasm-sgx-vm"
+AZURE_SGX_VM_IMAGE = "Canonical:UbuntuServer:18_04-lts-gen2:18.04.202109180"
+AZURE_SGX_VM_ADMIN_USERNAME = "faasm"
+AZURE_SGX_VM_SSH_KEY_FILE = "{}/experiments/sgx/pkeys".format(PROJ_ROOT)
+
+# Attestation config
+
+AZURE_ATTESTATION_PROVIDER_NAME = "faasmattprov"
+AZURE_ATTESTATION_TYPE = "SGX-IntelSDK"

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -1,0 +1,136 @@
+from invoke import task
+from tasks.util.env import (
+    AZURE_RESOURCE_GROUP,
+    AZURE_SGX_VM_SIZE,
+    AZURE_SGX_LOCATION,
+    AZURE_SGX_VM_IMAGE,
+    AZURE_SGX_VM_NAME,
+    AZURE_SGX_VM_ADMIN_USERNAME,
+    AZURE_SGX_VM_SSH_KEY_FILE,
+)
+from subprocess import check_output, run
+
+
+def _run_vm_cmd(name, az_args=None, capture_stdout=False):
+    cmd = [
+        "az",
+        "vm {}".format(name),
+        "--resource-group {}".format(AZURE_RESOURCE_GROUP),
+    ]
+
+    if az_args:
+        cmd.extend(az_args)
+
+    cmd = " ".join(cmd)
+    print(cmd)
+    if capture_stdout:
+        return check_output(cmd, shell=True)
+    else:
+        run(cmd, shell=True, check=True)
+
+
+def _run_del_network_cmd(name, suffix):
+    cmd = [
+        "az",
+        "network {}".format(name),
+        "delete",
+        "--resource-group {}".format(AZURE_RESOURCE_GROUP),
+        "--name {}{}".format(AZURE_SGX_VM_NAME, suffix),
+    ]
+
+    cmd = " ".join(cmd)
+    print(cmd)
+    run(cmd, shell=True, check=True)
+
+
+@task
+def provision(ctx):
+    """
+    Provision SGX-enabled VM
+    """
+    _run_vm_cmd(
+        "create",
+        [
+            "--name {}".format(AZURE_SGX_VM_NAME),
+            "--location {}".format(AZURE_SGX_LOCATION),
+            "--image {}".format(AZURE_SGX_VM_IMAGE),
+            "--size {}".format(AZURE_SGX_VM_SIZE),
+            "--authentication-type ssh",
+            "--public-ip-sku Standard",
+            "--admin-username {}".format(AZURE_SGX_VM_ADMIN_USERNAME),
+            "--generate-ssh-keys",
+            "--ssh-key-values {}".format(AZURE_SGX_VM_SSH_KEY_FILE),
+        ],
+    )
+
+
+def get_os_disk():
+    out = _run_vm_cmd(
+        "show",
+        [
+            "--name {}".format(AZURE_SGX_VM_NAME),
+            "--query storageProfile.osDisk.managedDisk.id",
+        ],
+        capture_stdout=True,
+    ).decode("utf-8")
+    return out.split("/")[-1][:-2]
+
+
+def get_ip():
+    out = check_output(
+        "az network public-ip show --resource-group {} --name {}PublicIp --query ipAddress".format(
+            AZURE_RESOURCE_GROUP, AZURE_SGX_VM_NAME
+        ),
+        shell=True,
+    )
+    return out.decode("utf-8").strip().strip('"')
+
+
+@task
+def get_ssh(ctx):
+    """
+    Get the SSH config to log into the SGX VM
+    """
+    ssh_config = [
+        "Host {}".format(AZURE_SGX_VM_NAME),
+        "\n    HostName {}".format(get_ip()),
+        "\n    User {}".format(AZURE_SGX_VM_ADMIN_USERNAME),
+        "\n    ForwardAgent yes",
+    ]
+    print(" ".join(ssh_config))
+
+
+@task
+def delete(ctx):
+    """
+    Delete SGX VM
+    """
+    os_disk = get_os_disk()
+
+    # Delete VM
+    _run_vm_cmd(
+        "delete",
+        [
+            "--name {}".format(AZURE_SGX_VM_NAME),
+            "--yes",
+        ],
+    )
+
+    # Delete OS disk
+    run(
+        "az disk delete --resource-group {} --name {} --yes".format(
+            AZURE_RESOURCE_GROUP, os_disk
+        ),
+        shell=True,
+    )
+
+    # Network components to be deleted, order matters
+    net_components = [
+        ("nic", "VMNic"),
+        ("nsg", "NSG"),
+        ("vnet", "VNET"),
+        ("public-ip", "PublicIp"),
+    ]
+
+    for name, suffix in net_components:
+        _run_del_network_cmd(name, suffix)


### PR DESCRIPTION
In this PR I add a couple of tasks to interact with the attestation provider and get/set attestation policies.

I also move the tasks to provision and delete an SGX-enabled VM, which previously  lived in a branch of `experiment-base`. After thinking about it I feel it fits here better.